### PR TITLE
Feature: support equity index security types for history requests

### DIFF
--- a/QuantConnect.ThetaData.Tests/TestHelpers.cs
+++ b/QuantConnect.ThetaData.Tests/TestHelpers.cs
@@ -30,12 +30,12 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
     public static class TestHelpers
     {
         /// <summary>
-        /// Represents the time zone used by ThetaData, which returns time in the Eastern Time (ET) Time Zone.
+        /// Represents the time zone used by ThetaData, which returns time in the New York (EST) Time Zone with daylight savings time.
         /// </summary>
         /// <remarks>
         /// <see href="https://http-docs.thetadata.us/docs/theta-data-rest-api-v2/ke230k18g7fld-trading-hours"/>
         /// </remarks>
-        private static DateTimeZone TimeZoneThetaData = TimeZones.EasternStandard;
+        private static DateTimeZone TimeZoneThetaData = TimeZones.NewYork;
 
         public static void ValidateHistoricalBaseData(IEnumerable<BaseData> history, Resolution resolution, TickType tickType, DateTime startDate, DateTime endDate, Symbol requestedSymbol = null)
         {

--- a/QuantConnect.ThetaData.Tests/TestHelpers.cs
+++ b/QuantConnect.ThetaData.Tests/TestHelpers.cs
@@ -29,6 +29,14 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
 {
     public static class TestHelpers
     {
+        /// <summary>
+        /// Represents the time zone used by ThetaData, which returns time in the Eastern Time (ET) Time Zone.
+        /// </summary>
+        /// <remarks>
+        /// <see href="https://http-docs.thetadata.us/docs/theta-data-rest-api-v2/ke230k18g7fld-trading-hours"/>
+        /// </remarks>
+        private static DateTimeZone TimeZoneThetaData = TimeZones.EasternStandard;
+
         public static void ValidateHistoricalBaseData(IEnumerable<BaseData> history, Resolution resolution, TickType tickType, DateTime startDate, DateTime endDate, Symbol requestedSymbol = null)
         {
             Assert.IsNotNull(history);
@@ -36,13 +44,13 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
 
             if (resolution < Resolution.Daily)
             {
-                Assert.That(history.First().Time.Date, Is.EqualTo(startDate.ConvertFromUtc(TimeZones.EasternStandard).Date));
-                Assert.That(history.Last().Time.Date, Is.EqualTo(endDate.ConvertFromUtc(TimeZones.EasternStandard).Date));
+                Assert.That(history.First().Time.Date, Is.EqualTo(startDate.ConvertFromUtc(TimeZoneThetaData).Date));
+                Assert.That(history.Last().Time.Date, Is.EqualTo(endDate.ConvertFromUtc(TimeZoneThetaData).Date));
             }
             else
             {
-                Assert.That(history.First().Time.Date, Is.GreaterThanOrEqualTo(startDate.ConvertFromUtc(TimeZones.EasternStandard).Date));
-                Assert.That(history.Last().Time.Date, Is.LessThanOrEqualTo(endDate.ConvertFromUtc(TimeZones.EasternStandard).Date));
+                Assert.That(history.First().Time.Date, Is.GreaterThanOrEqualTo(startDate.ConvertFromUtc(TimeZoneThetaData).Date));
+                Assert.That(history.Last().Time.Date, Is.LessThanOrEqualTo(endDate.ConvertFromUtc(TimeZoneThetaData).Date));
             }
 
             switch (tickType)
@@ -143,7 +151,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
                 Assert.That(tradeBar.Low, Is.GreaterThan(0));
                 Assert.That(tradeBar.Close, Is.GreaterThan(0));
                 Assert.That(tradeBar.Price, Is.GreaterThan(0));
-                Assert.That(tradeBar.Volume, Is.GreaterThan(0));
+                Assert.That(tradeBar.Volume, Is.GreaterThanOrEqualTo(0));
                 Assert.That(tradeBar.Time, Is.GreaterThan(default(DateTime)));
                 Assert.That(tradeBar.EndTime, Is.GreaterThan(default(DateTime)));
             }
@@ -174,7 +182,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
                 null,
                 true,
                 false,
-                DataNormalizationMode.Adjusted,
+                DataNormalizationMode.Raw,
                 tickType
                 );
         }

--- a/QuantConnect.ThetaData.Tests/TestHelpers.cs
+++ b/QuantConnect.ThetaData.Tests/TestHelpers.cs
@@ -58,8 +58,11 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
                 case TickType.Trade when resolution != Resolution.Tick:
                     AssertTradeBars(history.Select(x => x as TradeBar), requestedSymbol, resolution.ToTimeSpan());
                     break;
-                case TickType.Trade:
+                case TickType.Trade when requestedSymbol.SecurityType != SecurityType.Index:
                     AssertTradeTickBars(history.Select(x => x as Tick), requestedSymbol);
+                    break;
+                case TickType.Trade when requestedSymbol.SecurityType == SecurityType.Index:
+                    AssertIndexTradeTickBars(history.Select(x => x as Tick), requestedSymbol);
                     break;
                 case TickType.Quote when resolution == Resolution.Tick:
                     AssertQuoteTickBars(history.Select(x => x as Tick), requestedSymbol);
@@ -82,6 +85,19 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
                 Assert.That(tick.Price, Is.GreaterThan(0));
                 Assert.That(tick.Value, Is.GreaterThan(0));
                 Assert.IsNotEmpty(tick.SaleCondition);
+            }
+        }
+
+        public static void AssertIndexTradeTickBars(IEnumerable<Tick> ticks, Symbol symbol = null)
+        {
+            foreach (var tick in ticks)
+            {
+                if (symbol != null)
+                {
+                    Assert.That(tick.Symbol, Is.EqualTo(symbol));
+                }
+
+                Assert.That(tick.Price, Is.GreaterThan(0));
             }
         }
 

--- a/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
+++ b/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
@@ -60,5 +60,40 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
 
             TestHelpers.ValidateHistoricalBaseData(history, resolution, tickType, startDate, endDate, symbol);
         }
+
+        [TestCase("AAPL", Resolution.Tick, TickType.Trade, "2024/07/02", "2024/07/30", Explicit = true, Description = "Skipped: Long execution time")]
+        [TestCase("AAPL", Resolution.Tick, TickType.Quote, "2024/07/26", "2024/07/30", Explicit = true, Description = "Skipped: Long execution time")]
+        [TestCase("AAPL", Resolution.Tick, TickType.Trade, "2024/07/26", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Second, TickType.Trade, "2024/07/02", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Second, TickType.Quote, "2024/07/02", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Minute, TickType.Trade, "2024/07/02", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Minute, TickType.Quote, "2024/07/02", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Hour, TickType.Trade, "2024/07/26", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Hour, TickType.Trade, "2024/07/02", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Hour, TickType.Quote, "2024/07/02", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Daily, TickType.Trade, "2024/07/01", "2024/07/30")]
+        [TestCase("AAPL", Resolution.Daily, TickType.Quote, "2024/07/01", "2024/07/30")]
+        public void GetHistoryEquityData(string ticker, Resolution resolution, TickType tickType, DateTime startDate, DateTime endDate)
+        {
+            var symbol = TestHelpers.CreateSymbol(ticker, SecurityType.Equity);
+
+            var historyRequest = TestHelpers.CreateHistoryRequest(symbol, resolution, tickType, startDate, endDate);
+
+            var history = _thetaDataProvider.GetHistory(historyRequest).ToList();
+
+            TestHelpers.ValidateHistoricalBaseData(history, resolution, tickType, startDate, endDate, symbol);
+        }
+
+        [TestCase("SPX", Resolution.Daily, TickType.Trade, "2024/07/01", "2024/07/30")]
+        public void GetHistoryIndexData(string ticker, Resolution resolution, TickType tickType, DateTime startDate, DateTime endDate)
+        {
+            var symbol = TestHelpers.CreateSymbol(ticker, SecurityType.Index);
+
+            var historyRequest = TestHelpers.CreateHistoryRequest(symbol, resolution, tickType, startDate, endDate);
+
+            var history = _thetaDataProvider.GetHistory(historyRequest).ToList();
+
+            TestHelpers.ValidateHistoricalBaseData(history, resolution, tickType, startDate, endDate, symbol);
+        }
     }
 }

--- a/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
+++ b/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
@@ -100,5 +100,19 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
 
             TestHelpers.ValidateHistoricalBaseData(history, resolution, tickType, startDate, endDate, symbol);
         }
+
+        [TestCase("AAPL", Resolution.Tick, TickType.Trade, "2024/07/24", "2024/07/26", Explicit = true, Description = "Skipped: Long execution time")]
+        public void GetHistoryTickTradeValidateOnDistinctData(string ticker, Resolution resolution, TickType tickType, DateTime startDate, DateTime endDate)
+        {
+            var symbol = TestHelpers.CreateSymbol(ticker, SecurityType.Equity);
+
+            var historyRequest = TestHelpers.CreateHistoryRequest(symbol, resolution, tickType, startDate, endDate);
+
+            var history = _thetaDataProvider.GetHistory(historyRequest).ToList();
+
+            var distinctHistory = history.Distinct().ToList();
+
+            Assert.That(history.Count, Is.EqualTo(distinctHistory.Count));
+        }
     }
 }

--- a/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
+++ b/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
         [TestCase("AAPL", SecurityType.Option, Resolution.Hour, TickType.OpenInterest, "2024/03/18", "2024/03/28", Description = "Wrong Resolution for OpenInterest")]
         [TestCase("AAPL", SecurityType.Option, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/03/18", Description = "StartDate > EndDate")]
         [TestCase("AAPL", SecurityType.Equity, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/04/02", Description = "Wrong TickType")]
+        [TestCase("AAPL", SecurityType.Equity, Resolution.Daily, TickType.Trade, "2024/07/07", "2024/07/08", Description = "Use Weekend data, No data return")]
         [TestCase("AAPL", SecurityType.FutureOption, Resolution.Hour, TickType.Trade, "2024/03/28", "2024/03/18", Description = "Wrong SecurityType")]
         [TestCase("SPY", SecurityType.Index, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/04/02", Description = "Wrong TickType, Index support only Trade")]
         [TestCase("SPY", SecurityType.Index, Resolution.Minute, TickType.Quote, "2024/03/28", "2024/04/02", Description = "Wrong TickType, Index support only Trade")]

--- a/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
+++ b/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
@@ -28,8 +28,10 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
 
         [TestCase("AAPL", SecurityType.Option, Resolution.Hour, TickType.OpenInterest, "2024/03/18", "2024/03/28", Description = "Wrong Resolution for OpenInterest")]
         [TestCase("AAPL", SecurityType.Option, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/03/18", Description = "StartDate > EndDate")]
-        [TestCase("AAPL", SecurityType.Equity, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/03/18", Description = "Wrong SecurityType")]
+        [TestCase("AAPL", SecurityType.Equity, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/04/02", Description = "Wrong TickType")]
         [TestCase("AAPL", SecurityType.FutureOption, Resolution.Hour, TickType.Trade, "2024/03/28", "2024/03/18", Description = "Wrong SecurityType")]
+        [TestCase("SPY", SecurityType.Index, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/04/02", Description = "Wrong TickType, Index support only Trade")]
+        [TestCase("SPY", SecurityType.Index, Resolution.Minute, TickType.Quote, "2024/03/28", "2024/04/02", Description = "Wrong TickType, Index support only Trade")]
         public void TryGetHistoryDataWithInvalidRequestedParameters(string ticker, SecurityType securityType, Resolution resolution, TickType tickType, DateTime startDate, DateTime endDate)
         {
             var symbol = TestHelpers.CreateSymbol(ticker, securityType, OptionRight.Call, 170, new DateTime(2024, 03, 28));

--- a/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
+++ b/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
@@ -25,8 +25,6 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
     {
         ThetaDataProvider _thetaDataProvider = new();
 
-
-        [TestCase("AAPL", SecurityType.Option, Resolution.Hour, TickType.OpenInterest, "2024/03/18", "2024/03/28", Description = "Wrong Resolution for OpenInterest")]
         [TestCase("AAPL", SecurityType.Option, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/03/18", Description = "StartDate > EndDate")]
         [TestCase("AAPL", SecurityType.Equity, Resolution.Hour, TickType.OpenInterest, "2024/03/28", "2024/04/02", Description = "Wrong TickType")]
         [TestCase("AAPL", SecurityType.Equity, Resolution.Daily, TickType.Trade, "2024/07/07", "2024/07/08", Description = "Use Weekend data, No data return")]

--- a/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
+++ b/QuantConnect.ThetaData.Tests/ThetaDataHistoryProviderTests..cs
@@ -84,6 +84,10 @@ namespace QuantConnect.Lean.DataSource.ThetaData.Tests
             TestHelpers.ValidateHistoricalBaseData(history, resolution, tickType, startDate, endDate, symbol);
         }
 
+        [TestCase("SPX", Resolution.Tick, TickType.Trade, "2024/07/02", "2024/07/30")]
+        [TestCase("SPX", Resolution.Second, TickType.Trade, "2024/07/02", "2024/07/30")]
+        [TestCase("SPX", Resolution.Minute, TickType.Trade, "2024/07/02", "2024/07/30")]
+        [TestCase("SPX", Resolution.Hour, TickType.Trade, "2024/07/02", "2024/07/30")]
         [TestCase("SPX", Resolution.Daily, TickType.Trade, "2024/07/01", "2024/07/30")]
         public void GetHistoryIndexData(string ticker, Resolution resolution, TickType tickType, DateTime startDate, DateTime endDate)
         {

--- a/QuantConnect.ThetaData/Converters/ThetaDataOpenHighLowCloseConverter.cs
+++ b/QuantConnect.ThetaData/Converters/ThetaDataOpenHighLowCloseConverter.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using QuantConnect.Lean.DataSource.ThetaData.Models.Rest;
+using System.Globalization;
+
+namespace QuantConnect.Lean.DataSource.ThetaData.Converters;
+
+/// <summary>
+/// JSON converter to convert ThetaData OpenHighLowClose
+/// </summary>
+public class ThetaDataOpenHighLowCloseConverter : JsonConverter<OpenHighLowCloseResponse>
+{
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="JsonConverter"/> can write JSON.
+    /// </summary>
+    /// <value><c>true</c> if this <see cref="JsonConverter"/> can write JSON; otherwise, <c>false</c>.</value>
+    public override bool CanWrite => false;
+
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="JsonConverter"/> can read JSON.
+    /// </summary>
+    /// <value><c>true</c> if this <see cref="JsonConverter"/> can read JSON; otherwise, <c>false</c>.</value>
+    public override bool CanRead => true;
+
+    /// <summary>
+    /// Writes the JSON representation of the object.
+    /// </summary>
+    /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    public override void WriteJson(JsonWriter writer, OpenHighLowCloseResponse value, JsonSerializer serializer)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Reads the JSON representation of the object.
+    /// </summary>
+    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+    /// <param name="objectType">Type of the object.</param>
+    /// <param name="existingValue">The existing value of object being read.</param>
+    /// <param name="hasExistingValue">The existing value has a value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    /// <returns>The object value.</returns>
+    public override OpenHighLowCloseResponse ReadJson(JsonReader reader, Type objectType, OpenHighLowCloseResponse existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        var token = JToken.Load(reader);
+        if (token.Type != JTokenType.Array || token.Count() != 8) throw new Exception($"{nameof(ThetaDataQuoteConverter)}.{nameof(ReadJson)}: Invalid token type or count. Expected a JSON array with exactly four elements.");
+
+        return new OpenHighLowCloseResponse(
+            timeMilliseconds: token[0]!.Value<uint>(),
+            open: token[1]!.Value<decimal>(),
+            high: token[2]!.Value<decimal>(),
+            low: token[3]!.Value<decimal>(),
+            close: token[4]!.Value<decimal>(),
+            volume: token[5]!.Value<decimal>(),
+            count: token[6]!.Value<uint>(),
+            date: DateTime.ParseExact(token[7]!.ToString(), "yyyyMMdd", CultureInfo.InvariantCulture));
+    }
+}

--- a/QuantConnect.ThetaData/Converters/ThetaDataPriceConverter.cs
+++ b/QuantConnect.ThetaData/Converters/ThetaDataPriceConverter.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+using QuantConnect.Lean.DataSource.ThetaData.Models.Rest;
+
+namespace QuantConnect.Lean.DataSource.ThetaData.Converters;
+
+/// <summary>
+/// JSON converter to convert ThetaData Price
+/// </summary>
+public class ThetaDataPriceConverter : JsonConverter<PriceResponse>
+{
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="JsonConverter"/> can write JSON.
+    /// </summary>
+    /// <value><c>true</c> if this <see cref="JsonConverter"/> can write JSON; otherwise, <c>false</c>.</value>
+    public override bool CanWrite => false;
+
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="JsonConverter"/> can read JSON.
+    /// </summary>
+    /// <value><c>true</c> if this <see cref="JsonConverter"/> can read JSON; otherwise, <c>false</c>.</value>
+    public override bool CanRead => true;
+
+    /// <summary>
+    /// Writes the JSON representation of the object.
+    /// </summary>
+    /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    public override void WriteJson(JsonWriter writer, PriceResponse value, JsonSerializer serializer)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Reads the JSON representation of the object.
+    /// </summary>
+    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+    /// <param name="objectType">Type of the object.</param>
+    /// <param name="existingValue">The existing value of object being read.</param>
+    /// <param name="hasExistingValue">The existing value has a value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    /// <returns>The object value.</returns>
+    public override PriceResponse ReadJson(JsonReader reader, Type objectType, PriceResponse existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        var token = JToken.Load(reader);
+        if (token.Type != JTokenType.Array || token.Count() != 3) throw new Exception($"{nameof(ThetaDataQuoteConverter)}.{nameof(ReadJson)}: Invalid token type or count. Expected a JSON array with exactly four elements.");
+
+        return new PriceResponse(
+            timeMilliseconds: token[0]!.Value<uint>(),
+            price: token[1]!.Value<decimal>(),
+            date: DateTime.ParseExact(token[2]!.ToString(), "yyyyMMdd", CultureInfo.InvariantCulture));
+    }
+}

--- a/QuantConnect.ThetaData/Models/Enums/ContractSecurityType.cs
+++ b/QuantConnect.ThetaData/Models/Enums/ContractSecurityType.cs
@@ -25,6 +25,9 @@ public enum ContractSecurityType
     [EnumMember(Value = "OPTION")]
     Option = 0,
 
-    [EnumMember(Value = "EQUITY")]
+    [EnumMember(Value = "STOCK")]
     Equity = 1,
+
+    [EnumMember(Value = "INDEX")]
+    Index = 2
 }

--- a/QuantConnect.ThetaData/Models/Enums/WebSocketHeaderType.cs
+++ b/QuantConnect.ThetaData/Models/Enums/WebSocketHeaderType.cs
@@ -33,4 +33,10 @@ public enum WebSocketHeaderType
 
     [EnumMember(Value = "OHLC")]
     Ohlc = 3,
+
+    [EnumMember(Value = "REQ_RESPONSE")]
+    ReqResponse = 4,
+
+    [EnumMember(Value = "STATE")]
+    State = 5
 }

--- a/QuantConnect.ThetaData/Models/Rest/OpenHighLowCloseResponse.cs
+++ b/QuantConnect.ThetaData/Models/Rest/OpenHighLowCloseResponse.cs
@@ -1,0 +1,94 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Newtonsoft.Json;
+using QuantConnect.Lean.DataSource.ThetaData.Converters;
+
+namespace QuantConnect.Lean.DataSource.ThetaData.Models.Rest;
+
+[JsonConverter(typeof(ThetaDataOpenHighLowCloseConverter))]
+public readonly struct OpenHighLowCloseResponse
+{
+    /// <summary>
+    /// The milliseconds since 00:00:00.000 (midnight) Eastern Time (ET).
+    /// </summary>
+    public uint TimeMilliseconds { get; }
+
+    /// <summary>
+    /// The opening trade price.
+    /// </summary>
+    public decimal Open { get; }
+
+    /// <summary>
+    /// The highest traded price.
+    /// </summary>
+    public decimal High { get; }
+
+    /// <summary>
+    /// The lowest traded price.
+    /// </summary>
+    public decimal Low { get; }
+
+    /// <summary>
+    /// The closing traded price.
+    /// </summary>
+    public decimal Close { get; }
+
+    /// <summary>
+    /// The amount of contracts traded.
+    /// </summary>
+    public decimal Volume { get; }
+
+    /// <summary>
+    /// The amount of trades.
+    /// </summary>
+    public uint Count { get; }
+
+    /// <summary>
+    /// The date formatted as YYYYMMDD. (e.g. "20240328" -> 2024/03/28)
+    /// </summary>
+    public DateTime Date { get; }
+
+    /// <summary>
+    /// Gets the DateTime representation of the last quote time. DateTime is New York Time (EST) Time Zone!
+    /// </summary>
+    /// <remarks>
+    /// This property calculates the <see cref="Date"/> by adding the <seealso cref="TimeMilliseconds"/> to the Date property.
+    /// </remarks>
+    public DateTime DateTimeMilliseconds { get => Date.AddMilliseconds(TimeMilliseconds); }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenHighLowCloseResponse"/> struct.
+    /// </summary>
+    /// <param name="timeMilliseconds">The milliseconds since 00:00:00.000 (midnight) Eastern Time (ET).</param>
+    /// <param name="open">The opening trade price.</param>
+    /// <param name="high">The highest traded price.</param>
+    /// <param name="low">The lowest traded price.</param>
+    /// <param name="close">The closing traded price.</param>
+    /// <param name="volume">The amount of contracts traded.</param>
+    /// <param name="count">The amount of trades.</param>
+    /// <param name="date">The date formatted as YYYYMMDD.</param>
+    public OpenHighLowCloseResponse(uint timeMilliseconds, decimal open, decimal high, decimal low, decimal close, decimal volume, uint count, DateTime date)
+    {
+        TimeMilliseconds = timeMilliseconds;
+        Open = open;
+        High = high;
+        Low = low;
+        Close = close;
+        Volume = volume;
+        Count = count;
+        Date = date;
+    }
+}

--- a/QuantConnect.ThetaData/Models/Rest/PriceResponse.cs
+++ b/QuantConnect.ThetaData/Models/Rest/PriceResponse.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Newtonsoft.Json;
+using QuantConnect.Lean.DataSource.ThetaData.Converters;
+
+namespace QuantConnect.Lean.DataSource.ThetaData.Models.Rest;
+
+/// <summary>
+/// Represents a response containing price response data.
+/// </summary>
+[JsonConverter(typeof(ThetaDataPriceConverter))]
+public readonly struct PriceResponse
+{
+    /// <summary>
+    /// Gets the time at which open interest was reported, represented in milliseconds since 00:00:00.000 (midnight) Eastern Time (ET).
+    /// </summary>
+    public uint TimeMilliseconds { get; }
+
+    /// <summary>
+    /// The reported price of the index.
+    /// </summary>
+    public decimal Price { get; }
+
+    /// <summary>
+    /// The date formatted as YYYYMMDD. (e.g. "20240328" -> 2024/03/28)
+    /// </summary>
+    public DateTime Date { get; }
+
+    /// <summary>
+    /// Gets the DateTime representation of the last quote time. DateTime is New York Time (EST) Time Zone!
+    /// </summary>
+    /// <remarks>
+    /// This property calculates the <see cref="Date"/> by adding the <seealso cref="TimeMilliseconds"/> to the Date property.
+    /// </remarks>
+    public DateTime DateTimeMilliseconds { get => Date.AddMilliseconds(TimeMilliseconds); }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PriceResponse"/> struct.
+    /// </summary>
+    /// <param name="timeMilliseconds">The milliseconds since 00:00:00.000 (midnight) Eastern Time (ET).</param>
+    /// <param name="price">The reported price of the index.</param>
+    /// <param name="date">The date formatted as YYYYMMDD.</param>
+    public PriceResponse(uint timeMilliseconds, decimal price, DateTime date)
+    {
+        TimeMilliseconds = timeMilliseconds;
+        Price = price;
+        Date = date;
+    }
+}

--- a/QuantConnect.ThetaData/Models/WebSocket/WebSocketHeader.cs
+++ b/QuantConnect.ThetaData/Models/WebSocket/WebSocketHeader.cs
@@ -32,13 +32,13 @@ public readonly struct WebSocketHeader
     public string Response { get; }
 
     [JsonProperty("req_id")]
-    public uint RequestId { get; }
+    public int RequestId { get; }
 
     [JsonProperty("state")]
     public string State { get; }
 
     [JsonConstructor]
-    public WebSocketHeader(WebSocketHeaderType type, string status, string response, uint requestId, string state)
+    public WebSocketHeader(WebSocketHeaderType type, string status, string response, int requestId, string state)
     {
         Type = type;
         Status = status;

--- a/QuantConnect.ThetaData/Models/WebSocket/WebSocketHeader.cs
+++ b/QuantConnect.ThetaData/Models/WebSocket/WebSocketHeader.cs
@@ -28,10 +28,22 @@ public readonly struct WebSocketHeader
     [JsonProperty("status")]
     public string Status { get; }
 
+    [JsonProperty("response")]
+    public string Response { get; }
+
+    [JsonProperty("req_id")]
+    public uint RequestId { get; }
+
+    [JsonProperty("state")]
+    public string State { get; }
+
     [JsonConstructor]
-    public WebSocketHeader(WebSocketHeaderType type, string status)
+    public WebSocketHeader(WebSocketHeaderType type, string status, string response, uint requestId, string state)
     {
         Type = type;
         Status = status;
+        Response = response;
+        RequestId = requestId;
+        State = state;
     }
 }

--- a/QuantConnect.ThetaData/Models/WebSocket/WebSocketTrade.cs
+++ b/QuantConnect.ThetaData/Models/WebSocket/WebSocketTrade.cs
@@ -51,9 +51,9 @@ public readonly struct WebSocketTrade
     public DateTime DateTimeMilliseconds { get => Date.AddMilliseconds(TimeMilliseconds); }
 
     [JsonConstructor]
-    public WebSocketTrade(int dayTimeMilliseconds, int sequence, int size, int condition, decimal price, byte exchange, DateTime date)
+    public WebSocketTrade(int timeMilliseconds, int sequence, int size, int condition, decimal price, byte exchange, DateTime date)
     {
-        TimeMilliseconds = dayTimeMilliseconds;
+        TimeMilliseconds = timeMilliseconds;
         Sequence = sequence;
         Size = size;
         Condition = condition;

--- a/QuantConnect.ThetaData/ThetaDataExtensions.cs
+++ b/QuantConnect.ThetaData/ThetaDataExtensions.cs
@@ -34,6 +34,36 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         public static string ConvertToThetaDataDateFormat(this DateTime date) => date.ToStringInvariant(DateFormat.EightCharacter);
 
         /// <summary>
+        /// Generates date ranges with each range covering a specified number of days from the specified <paramref name="startDate"/> to <paramref name="endDate"/>.
+        /// </summary>
+        /// <param name="startDate">The starting date (inclusive) of the date range.</param>
+        /// <param name="endDate">The ending date (exclusive) of the date range.</param>
+        /// <param name="intervalDays">The number of days each date range should cover.</param>
+        /// <returns>An enumerable sequence of tuples where each tuple contains a start date (inclusive) and end date (exclusive) covering the specified number of days.</returns>
+        /// <remarks>
+        /// <see href="https://http-docs.thetadata.us/docs/theta-data-rest-api-v2/d1g9022y8z6sb-request-sizing"/>
+        /// <para>
+        /// Best Practices for request interval size and duration:
+        /// Making large requests is often times inefficient and can lead to out of memory errors.
+        /// Recommended date range limit for each type of resolution / asset class is under 1 million ticks.
+        /// Going over the recommended date range may cause client or server side out of memory errors.
+        /// </para>
+        /// </remarks>
+        public static IEnumerable<(DateTime startDate, DateTime endDate)> GenerateDateRangesWithInterval(DateTime startDate, DateTime endDate, int intervalDays = 1)
+        {
+            DateTime currentDate = startDate;
+
+            while (currentDate < endDate)
+            {
+                DateTime nextDate = currentDate.AddDays(intervalDays);
+                yield return (currentDate, nextDate);
+
+                // Move to the next interval
+                currentDate = nextDate;
+            }
+        }
+
+        /// <summary>
         /// Represents a collection of Exchanges with their corresponding numerical codes.
         /// </summary>
         public static Dictionary<byte, string> Exchanges = new()

--- a/QuantConnect.ThetaData/ThetaDataExtensions.cs
+++ b/QuantConnect.ThetaData/ThetaDataExtensions.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Globalization;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.DataSource.ThetaData
 {
@@ -62,6 +63,21 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                 currentDate = nextDate;
             }
         }
+
+        /// <summary>
+        /// Retrieves the time zone of the exchange for the given symbol.
+        /// </summary>
+        /// <param name="symbol">The symbol for which to get the exchange time zone.</param>
+        /// <returns>
+        /// The <see cref="NodaTime.DateTimeZone"/> representing the time zone of the exchange
+        /// where the given symbol is traded.
+        /// </returns>
+        /// <remarks>
+        /// This method uses the <see cref="MarketHoursDatabase"/> to fetch the exchange hours
+        /// and extract the time zone information for the provided symbol.
+        /// </remarks>
+        public static NodaTime.DateTimeZone GetSymbolExchangeTimeZone(this Symbol symbol)
+            => MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType).TimeZone;
 
         /// <summary>
         /// Represents a collection of Exchanges with their corresponding numerical codes.

--- a/QuantConnect.ThetaData/ThetaDataExtensions.cs
+++ b/QuantConnect.ThetaData/ThetaDataExtensions.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Globalization;
+using QuantConnect.Logging;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.DataSource.ThetaData
@@ -80,9 +81,29 @@ namespace QuantConnect.Lean.DataSource.ThetaData
             => MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType).TimeZone;
 
         /// <summary>
+        /// Attempts to get the exchange name corresponding to the given exchange number.
+        /// </summary>
+        /// <param name="exchangeNumber">The numerical code of the exchange.</param>
+        /// <returns>
+        /// The name of the exchange if found; otherwise, an empty string.
+        /// </returns>
+        /// <remarks>
+        /// Logs an error if the exchange number is not found in the dictionary.
+        /// </remarks>
+        public static string TryGetExchangeOrDefault(this byte exchangeNumber)
+        {
+            if (Exchanges.TryGetValue(exchangeNumber, out var exchange))
+            {
+                return exchange;
+            }
+            Log.Error($"{nameof(ThetaDataExtensions)}.{nameof(TryGetExchangeOrDefault)}: Exchange number {exchangeNumber} not found.");
+            return string.Empty;
+        }
+
+        /// <summary>
         /// Represents a collection of Exchanges with their corresponding numerical codes.
         /// </summary>
-        public static Dictionary<byte, string> Exchanges = new()
+        private static Dictionary<byte, string> Exchanges = new()
         {
             { 1, "NQEX" },
             { 2, "NQAD" },

--- a/QuantConnect.ThetaData/ThetaDataExtensions.cs
+++ b/QuantConnect.ThetaData/ThetaDataExtensions.cs
@@ -22,6 +22,11 @@ namespace QuantConnect.Lean.DataSource.ThetaData
     public static class ThetaDataExtensions
     {
         /// <summary>
+        /// Indicates whether the exchange message error has been fired.
+        /// </summary>
+        private static bool _isExchangeMessageFired;
+
+        /// <summary>
         /// Converts a date string from Theta data format (yyyyMMdd) to a DateTime object.
         /// </summary>
         /// <param name="date">The date string in Theta data format (e.g., "20240303" for March 3, 2024).</param>
@@ -96,7 +101,11 @@ namespace QuantConnect.Lean.DataSource.ThetaData
             {
                 return exchange;
             }
-            Log.Error($"{nameof(ThetaDataExtensions)}.{nameof(TryGetExchangeOrDefault)}: Exchange number {exchangeNumber} not found.");
+            if (!_isExchangeMessageFired)
+            {
+                _isExchangeMessageFired = true;
+                Log.Error($"{nameof(ThetaDataExtensions)}.{nameof(TryGetExchangeOrDefault)}: Exchange number {exchangeNumber} not found.");
+            }
             return string.Empty;
         }
 

--- a/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
@@ -223,7 +223,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                     request.AddQueryParameter("ivl", GetIntervalsInMilliseconds(resolution));
 
                     Func<QuoteResponse, BaseData> quoteCallback =
-                        (quote) => new Tick(ConvertThetaDataTimeZoneToSymbolExchangeTimeZone(quote.DateTimeMilliseconds, symbolExchangeTimeZone), symbol, quote.AskCondition, ThetaDataExtensions.Exchanges[quote.AskExchange], quote.BidSize, quote.BidPrice, quote.AskSize, quote.AskPrice);
+                        (quote) => new Tick(ConvertThetaDataTimeZoneToSymbolExchangeTimeZone(quote.DateTimeMilliseconds, symbolExchangeTimeZone), symbol, quote.AskCondition, quote.AskExchange.TryGetExchangeOrDefault(), quote.BidSize, quote.BidPrice, quote.AskSize, quote.AskPrice);
 
                     return GetHistoricalQuoteData(request, quoteCallback);
                 default:
@@ -306,7 +306,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                 {
                     foreach (var trade in trades.Response)
                     {
-                        yield return new Tick(ConvertThetaDataTimeZoneToSymbolExchangeTimeZone(trade.DateTimeMilliseconds, symbolExchangeTimeZone), symbol, trade.Condition.ToStringInvariant(), ThetaDataExtensions.Exchanges[trade.Exchange], trade.Size, trade.Price);
+                        yield return new Tick(ConvertThetaDataTimeZoneToSymbolExchangeTimeZone(trade.DateTimeMilliseconds, symbolExchangeTimeZone), symbol, trade.Condition.ToStringInvariant(), trade.Exchange.TryGetExchangeOrDefault(), trade.Size, trade.Price);
                     }
                 }
             }

--- a/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
@@ -61,15 +61,6 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// </remarks>
         private volatile bool _invalidIndexTickTypeWarningFired;
 
-        /// <summary>
-        /// Indicates whether a warning has been triggered for an invalid TickType request when the SecurityType is not 'Option'.
-        /// </summary>
-        /// <remarks>
-        /// This flag is set to true when a TickType of 'OpenInterest' is requested with a SecurityType other than 'Option'. 
-        /// This warning helps to prevent invalid requests since 'OpenInterest' is only supported for 'Option' security types.
-        /// </remarks>
-        private bool _invalidSecurityTypeOfOpenInterestWarningFired;
-
         /// <inheritdoc />
         public override void Initialize(HistoryProviderInitializeParameters parameters)
         { }
@@ -139,17 +130,6 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                 return null;
             }
 
-            if (historyRequest.TickType == TickType.OpenInterest && historyRequest.Symbol.SecurityType != SecurityType.Option)
-            {
-                // Log warning only once per instance
-                if (!_invalidSecurityTypeOfOpenInterestWarningFired)
-                {
-                    _invalidSecurityTypeOfOpenInterestWarningFired = true;
-                    Log.Trace($"{nameof(ThetaDataProvider)}.{nameof(GetHistory)}: Invalid data request. TickType 'OpenInterest' only supports SecurityType 'Option'. Requested: Resolution '{historyRequest.Resolution}', SecurityType '{historyRequest.Symbol.SecurityType}'.");
-                }
-                return null;
-            }
-
             if (historyRequest.Symbol.SecurityType == SecurityType.Index && historyRequest.TickType != TickType.Trade)
             {
                 if (!_invalidIndexTickTypeWarningFired)
@@ -172,7 +152,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
             {
                 return GetIndexIntradayHistoryData(restRequest, historyRequest.Symbol, historyRequest.Resolution);
             }
-            else if (historyRequest.TickType == TickType.OpenInterest && historyRequest.Symbol.SecurityType == SecurityType.Option || historyRequest.Symbol.SecurityType == SecurityType.IndexOption)
+            else if (historyRequest.TickType == TickType.OpenInterest)
             {
                 return GetHistoricalOpenInterestData(restRequest, historyRequest.Symbol);
             }

--- a/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
@@ -310,6 +310,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
             {
                 request.AddOrUpdateParameter("start_date", dateRange.startDate.ConvertToThetaDataDateFormat(), ParameterType.QueryString);
                 request.AddOrUpdateParameter("end_date", dateRange.endDate.ConvertToThetaDataDateFormat(), ParameterType.QueryString);
+                request.AddOrUpdateParameter("start_time", "0", ParameterType.QueryString);
 
                 foreach (var trades in _restApiClient.ExecuteRequest<BaseResponse<TradeResponse>>(request))
                 {

--- a/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataHistoryProvider.cs
@@ -187,6 +187,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         {
             request.AddQueryParameter("ivl", GetIntervalsInMilliseconds(resolution));
 
+            var period = resolution.ToTimeSpan();
             foreach (var prices in _restApiClient.ExecuteRequest<BaseResponse<PriceResponse>>(request))
             {
                 if (resolution == Resolution.Tick)
@@ -201,7 +202,6 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                 }
                 else
                 {
-                    var period = resolution.ToTimeSpan();
                     foreach (var price in prices.Response)
                     {
                         if (price.Price != 0m)

--- a/QuantConnect.ThetaData/ThetaDataProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataProvider.cs
@@ -175,9 +175,6 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                 return null;
             }
 
-            var enumerator = _dataAggregator.Add(dataConfig, newDataAvailableHandler);
-            _subscriptionManager.Subscribe(dataConfig);
-
             var exchangeTimeZone = dataConfig.Symbol.GetSymbolExchangeTimeZone();
             _exchangeTimeZoneByLeanSymbol[dataConfig.Symbol] = exchangeTimeZone;
 
@@ -186,6 +183,9 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                 _orderBooks[dataConfig.Symbol] = new DefaultOrderBook(dataConfig.Symbol);
                 _orderBooks[dataConfig.Symbol].BestBidAskUpdated += OnBestBidAskUpdated;
             }
+
+            var enumerator = _dataAggregator.Add(dataConfig, newDataAvailableHandler);
+            _subscriptionManager.Subscribe(dataConfig);
 
             return enumerator;
         }

--- a/QuantConnect.ThetaData/ThetaDataProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataProvider.cs
@@ -327,7 +327,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                 return;
             }
 
-            var tick = new Tick(DateTime.UtcNow.ConvertFromUtc(exchangeTimeZone), symbol, webSocketTrade.Condition.ToStringInvariant(), ThetaDataExtensions.Exchanges[webSocketTrade.Exchange], webSocketTrade.Size, webSocketTrade.Price);
+            var tick = new Tick(DateTime.UtcNow.ConvertFromUtc(exchangeTimeZone), symbol, webSocketTrade.Condition.ToStringInvariant(), webSocketTrade.Exchange.TryGetExchangeOrDefault(), webSocketTrade.Size, webSocketTrade.Price);
             lock (_lock)
             {
                 _dataAggregator.Update(tick);

--- a/QuantConnect.ThetaData/ThetaDataProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataProvider.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -153,8 +153,13 @@ namespace QuantConnect.Lean.DataSource.ThetaData
             throw new Exception($"{nameof(ThetaDataProvider)}.{nameof(OnError)}: {e.Message}");
         }
 
+        /// <summary>
+        /// Disposes of the resources used by the WebSocketClientWrapper instance.
+        /// Ensures that the WebSocket connection is properly closed and other resources are released safely.
+        /// </summary>
         public void Dispose()
         {
+            _webSocketClient?.Close();
             _dataAggregator?.DisposeSafely();
         }
 

--- a/QuantConnect.ThetaData/ThetaDataProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataProvider.cs
@@ -228,12 +228,12 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <returns>returns true if brokerage supports the specified symbol; otherwise false</returns>
-        private static bool CanSubscribe(Symbol symbol)
+        private bool CanSubscribe(Symbol symbol)
         {
             return
                 symbol.Value.IndexOfInvariant("universe", true) == -1 &&
                 !symbol.IsCanonical() &&
-                symbol.SecurityType == SecurityType.Option || symbol.SecurityType == SecurityType.IndexOption;
+                _symbolMapper.SupportedSecurityType.Contains(symbol.SecurityType);
         }
 
         /// <summary>

--- a/QuantConnect.ThetaData/ThetaDataProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataProvider.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// </summary>
         public void Dispose()
         {
-            _webSocketClient?.Close();
+            _webSocketClient?.CloseWebSocketConnection();
             _dataAggregator?.DisposeSafely();
         }
 

--- a/QuantConnect.ThetaData/ThetaDataProvider.cs
+++ b/QuantConnect.ThetaData/ThetaDataProvider.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -195,6 +195,8 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                     break;
                 case WebSocketHeaderType.Status when isInternetDisconnected:
                     isInternetDisconnected = !_webSocketClient.Subscribe(_subscriptionManager.GetSubscribedSymbols(), true);
+                    break;
+                case WebSocketHeaderType.Status when json.Header.Status == "CONNECTED":
                     break;
                 default:
                     Log.Debug(message);

--- a/QuantConnect.ThetaData/ThetaDataRestApiClient.cs
+++ b/QuantConnect.ThetaData/ThetaDataRestApiClient.cs
@@ -69,15 +69,16 @@ namespace QuantConnect.Lean.DataSource.ThetaData
 
                 var response = _restClient.Execute(request);
 
-                if (response == null || response.StatusCode == 0 || response.StatusCode != System.Net.HttpStatusCode.OK)
-                {
-                    throw new Exception($"{nameof(ThetaDataRestApiClient)}.{nameof(ExecuteRequest)}: No response received for request to {request.Resource}. Error message: {response?.ErrorMessage ?? "No error message available."}");
-                }
-
                 // docs: https://http-docs.thetadata.us/docs/theta-data-rest-api-v2/3ucp87xxgy8d3-error-codes
                 if ((int)response.StatusCode == 472)
                 {
-                    Log.Trace($"{nameof(ThetaDataRestApiClient)}.{nameof(ExecuteRequest)}:NO_DATA There was no data found for the specified request.");
+                    Log.Trace($"{nameof(ThetaDataRestApiClient)}.{nameof(ExecuteRequest)}:No data found for the specified request (Status Code: 472).");
+                    yield break;
+                }
+
+                if (response == null || response.StatusCode == 0 || response.StatusCode != System.Net.HttpStatusCode.OK)
+                {
+                    throw new Exception($"{nameof(ThetaDataRestApiClient)}.{nameof(ExecuteRequest)}: No response received for request to {request.Resource}. Error message: {response?.ErrorMessage ?? "No error message available."}");
                 }
 
                 var res = JsonConvert.DeserializeObject<T>(response.Content);

--- a/QuantConnect.ThetaData/ThetaDataRestApiClient.cs
+++ b/QuantConnect.ThetaData/ThetaDataRestApiClient.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// <param name="subscriptionPlan">User's ThetaData subscription price plan.</param>
         public ThetaDataRestApiClient(RateGate rateGate)
         {
-            _restClient = new RestClient(RestApiBaseUrl);
+            _restClient = new RestClient(RestApiBaseUrl + ApiVersion);
             _rateGate = rateGate;
         }
 
@@ -70,8 +70,6 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// <exception cref="Exception">Thrown when an error occurs during the execution of the request or when the response is invalid.</exception>
         public IEnumerable<T?> ExecuteRequest<T>(RestRequest? request) where T : IBaseResponse
         {
-            request.Resource = ApiVersion + request.Resource;
-
             while (request != null)
             {
                 Log.Debug($"{nameof(ThetaDataRestApiClient)}.{nameof(ExecuteRequest)}: URI: {_restClient.BuildUri(request)}");
@@ -102,7 +100,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
 
                 if (nextPage != null)
                 {
-                    request = new RestRequest(Method.GET) { Resource = nextPage.AbsolutePath };
+                    request = new RestRequest(Method.GET) { Resource = nextPage.AbsolutePath.Replace(ApiVersion, string.Empty) };
                 }
             };
         }

--- a/QuantConnect.ThetaData/ThetaDataRestApiClient.cs
+++ b/QuantConnect.ThetaData/ThetaDataRestApiClient.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                     yield break;
                 }
 
-                if (response == null || response.StatusCode == 0 || response.StatusCode != System.Net.HttpStatusCode.OK)
+                if (response == null || response.StatusCode != System.Net.HttpStatusCode.OK)
                 {
                     throw new Exception($"{nameof(ThetaDataRestApiClient)}.{nameof(ExecuteRequest)}: No response received for request to {request.Resource}. Error message: {response?.ErrorMessage ?? "No error message available."}");
                 }

--- a/QuantConnect.ThetaData/ThetaDataSymbolMapper.cs
+++ b/QuantConnect.ThetaData/ThetaDataSymbolMapper.cs
@@ -39,6 +39,14 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         private Dictionary<Symbol, string> _leanSymbolCache = new();
 
         /// <summary>
+        /// Represents a set of supported security types.
+        /// </summary>
+        /// <remarks>
+        /// This HashSet contains the supported security types that are allowed within the system.
+        /// </remarks>
+        public readonly HashSet<SecurityType> SupportedSecurityType = new() { SecurityType.Equity, SecurityType.Index, SecurityType.Option, SecurityType.IndexOption };
+
+        /// <summary>
         /// Converts a Lean symbol instance to a brokerage symbol.
         /// </summary>
         /// <param name="symbol">The Lean symbol instance to be converted.</param>

--- a/QuantConnect.ThetaData/ThetaDataSymbolMapper.cs
+++ b/QuantConnect.ThetaData/ThetaDataSymbolMapper.cs
@@ -108,8 +108,10 @@ namespace QuantConnect.Lean.DataSource.ThetaData
                         return GetLeanSymbol(root, SecurityType.Option, MARKET, dataProviderDate.ConvertFromThetaDataDateFormat(), strike, ConvertContractOptionRightFromThetaDataFormat(right));
                     case ContractSecurityType.Equity:
                         return GetLeanSymbol(root, SecurityType.Equity, MARKET);
+                    case ContractSecurityType.Index:
+                        return GetLeanSymbol(root, SecurityType.Index, MARKET);
                     default:
-                        throw new NotImplementedException("");
+                        throw new NotImplementedException($"{nameof(ThetaDataSymbolMapper)}.{nameof(GetLeanSymbol)}: The contract security type '{contractSecurityType}' is not implemented.");
                 }
             }
             return symbol;
@@ -211,6 +213,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
             {
                 case ContractSecurityType.Option:
                     return $"{ticker},{expirationDate},{strikePrice},{optionRight}";
+                case ContractSecurityType.Index:
                 case ContractSecurityType.Equity:
                     return ticker;
                 default:

--- a/QuantConnect.ThetaData/ThetaDataWebSocketClientWrapper.cs
+++ b/QuantConnect.ThetaData/ThetaDataWebSocketClientWrapper.cs
@@ -98,12 +98,12 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// Wraps the Close method to handle the closing of the WebSocket connection and
         /// ensures any ongoing streaming subscriptions are stopped before closing.
         /// </summary>
-        public new void Close()
+        public void CloseWebSocketConnection()
         {
             if (IsOpen)
             {
                 SendStopPreviousStreamingSubscriptions();
-                base.Close();
+                Close();
             }
         }
 
@@ -284,6 +284,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// </summary>
         private void SendStopPreviousStreamingSubscriptions()
         {
+            Log.Debug($"{nameof(ThetaDataWebSocketClientWrapper)}.{nameof(SendStopPreviousStreamingSubscriptions)}: Sending request to stop all previous streaming subscriptions to avoid conflicts and ensure clean state for new sessions.");
             Send(JsonConvert.SerializeObject(new { msg_type = "STOP" }));
         }
     }

--- a/QuantConnect.ThetaData/ThetaDataWebSocketClientWrapper.cs
+++ b/QuantConnect.ThetaData/ThetaDataWebSocketClientWrapper.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Lean.DataSource.ThetaData
         /// <param name="strikePrice">The strike price of the option contract.</param>
         /// <param name="optionRight">The option type, either "C" for call or "P" for put.</param>
         /// <returns>A JSON string representing the constructed message.</returns>
-        private string GetMessageOption(bool isSubscribe, string channelName, string ticker, string? expirationDate = default, string? strikePrice = default, string? optionRight = default)
+        private string GetMessageOption(bool isSubscribe, string channelName, string ticker, string expirationDate, string strikePrice, string optionRight)
         {
             return JsonConvert.SerializeObject(new
             {

--- a/QuantConnect.ThetaData/ThetaDataWebSocketClientWrapper.cs
+++ b/QuantConnect.ThetaData/ThetaDataWebSocketClientWrapper.cs
@@ -104,6 +104,12 @@ namespace QuantConnect.Lean.DataSource.ThetaData
             if (!IsOpen)
             {
                 Connect();
+
+                // Ensure all previous streaming subscriptions are stopped
+                // This is crucial to avoid any conflicts or unexpected behavior from previous sessions
+                // For more details, refer to the official documentation:
+                // https://http-docs.thetadata.us/docs/theta-data-rest-api-v2/a017d29vrw1q0-stop-all-streams
+                Send(JsonConvert.SerializeObject(new { msg_type = "STOP" }));
             }
 
             foreach (var symbol in symbols)

--- a/thetadata.json
+++ b/thetadata.json
@@ -9,7 +9,7 @@
       "Live Trading": [0, 1, 1]
     }
   ],
-  "data-supported": ["Equity Options", "Index Options"],
+  "data-supported": ["Equity", "Equity Options", "Indexes", "Index Options"],
   "documentation": "/docs/v2/lean-cli/datasets/thetadata",
   "more-information": "https://www.thetadata.net/",
   "module-specification": {
@@ -27,7 +27,9 @@
         "Daily"
       ],
       "security-types": [
+        "Equity",
         "Option",
+        "Index",
         "IndexOption"
       ],
       "markets": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This Pull Request introduces support for history provider data across various security types and resolutions. It refactors the existing implementation for `EquityOption` and extends support to `Equity`, `Index` security types with different tick types and resolutions. Additionally, it includes:
- Support for the Data Queue handler to enable live updates of Trade and Quote for Equity and Trade for Indexes.
- Implementation of actual order books.
- Improvements in the process of connection and reconnection, especially when the user loses internet connectivity.
- Improvements in the process of connection and reconnection, especially when the user loses internet connectivity.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind these changes is to enhance the capability of the history provider by supporting a broader range of security types and tick types. This update ensures comprehensive coverage and improved flexibility in retrieving historical data. It also aims to improve the real-time data handling and user experience by providing live updates and more reliable connections.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- **Implemented Support**: Added support for historical data retrieval for the following security types:
  - **Equity**:
    - `TickType.Trade` and `TickType.Quote` for resolutions: `Tick`, `Second`, `Minute`, `Hour`, and `Daily`.
  - **Option**: Same as `Equity`, with additional support for `TickType.OpenInterest` for `Resolution.Daily`.
  - **Index**:
    - `TickType.Trade` for resolutions: `Tick`, `Second`, `Minute`, `Hour`, and `Daily`.
- **Refactoring**: Refactored the previous implementation of EquityOption for improved performance and maintainability.
- **Additional Warning**: Added a warning mechanism to enhance user experience by providing clearer feedback.
- **Testing**:
  - Added comprehensive tests for `Equity` and `Index` security types with various parameters to ensure robustness.
  - Updated `GetHistory` method to handle incorrect parameters gracefully by returning a null response.
  - Tested the Data Queue handler for live updates of Trade and Quote for Equity and Trade for Indexes.
  - Verified the implementation of order books.
  - Tested the connection and reconnection processes to ensure reliability during internet connectivity issues.
  - Checked the accuracy of time updates using the specific time zone cache for different symbols.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
